### PR TITLE
Fix Dagger Injection

### DIFF
--- a/app/src/main/java/com/arjunalabs/android/xkcdreader/dagger/MainViewModelModule.kt
+++ b/app/src/main/java/com/arjunalabs/android/xkcdreader/dagger/MainViewModelModule.kt
@@ -1,6 +1,5 @@
 package com.arjunalabs.android.xkcdreader.dagger
 
-import com.arjunalabs.android.xkcdreader.repository.XKCDService
 import com.arjunalabs.android.xkcdreader.repository.XKCDServiceImpl
 import com.arjunalabs.android.xkcdreader.usecase.GetComicByNumber
 import com.arjunalabs.android.xkcdreader.usecase.GetComicByNumberImpl
@@ -8,7 +7,10 @@ import com.arjunalabs.android.xkcdreader.usecase.GetLatestComic
 import com.arjunalabs.android.xkcdreader.usecase.GetLatestComicImpl
 import dagger.Module
 import dagger.Provides
-import javax.inject.Singleton
+import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Named
 
 @Module
 class MainViewModelModule {
@@ -29,4 +31,12 @@ class MainViewModelModule {
     fun providesGetLatestComic(): GetLatestComic {
         return GetLatestComicImpl(XKCDServiceImpl.create())
     }
+
+    @Provides
+    @Named("schedulersIo")
+    fun providesSchedulersIo(): Scheduler = Schedulers.io()
+
+    @Provides
+    @Named("schedulersMainThread")
+    fun providesSchedulersMainThread(): Scheduler = AndroidSchedulers.mainThread()
 }

--- a/app/src/main/java/com/arjunalabs/android/xkcdreader/dagger/MainViewModelModule.kt
+++ b/app/src/main/java/com/arjunalabs/android/xkcdreader/dagger/MainViewModelModule.kt
@@ -1,6 +1,6 @@
 package com.arjunalabs.android.xkcdreader.dagger
 
-import com.arjunalabs.android.xkcdreader.repository.XKCDServiceImpl
+import com.arjunalabs.android.xkcdreader.repository.XKCDService
 import com.arjunalabs.android.xkcdreader.usecase.GetComicByNumber
 import com.arjunalabs.android.xkcdreader.usecase.GetComicByNumberImpl
 import com.arjunalabs.android.xkcdreader.usecase.GetLatestComic
@@ -12,24 +12,19 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Named
 
-@Module
+@Module(
+        includes = [RetrofitModule::class]
+)
 class MainViewModelModule {
 
-//    @Provides
-//    @Singleton
-//    open fun provideXKCDService(): XKCDService {
-//        return XKCDServiceImpl.create()
-//    }
-
-    // for now, the xkcdService is created here, we want to inject it like above does.
     @Provides
-    fun providesGetComicByNumber(): GetComicByNumber {
-        return GetComicByNumberImpl(XKCDServiceImpl.create())
+    fun providesGetComicByNumber(xkcdService: XKCDService): GetComicByNumber {
+        return GetComicByNumberImpl(xkcdService)
     }
 
     @Provides
-    fun providesGetLatestComic(): GetLatestComic {
-        return GetLatestComicImpl(XKCDServiceImpl.create())
+    fun providesGetLatestComic(xkcdService: XKCDService): GetLatestComic {
+        return GetLatestComicImpl(xkcdService)
     }
 
     @Provides

--- a/app/src/main/java/com/arjunalabs/android/xkcdreader/dagger/RetrofitModule.kt
+++ b/app/src/main/java/com/arjunalabs/android/xkcdreader/dagger/RetrofitModule.kt
@@ -1,0 +1,15 @@
+package com.arjunalabs.android.xkcdreader.dagger
+
+import com.arjunalabs.android.xkcdreader.repository.XKCDService
+import com.arjunalabs.android.xkcdreader.repository.XKCDServiceImpl
+import dagger.Module
+import dagger.Provides
+
+@Module
+class RetrofitModule {
+
+    @Provides
+    open fun provideXKCDService(): XKCDService {
+        return XKCDServiceImpl.create()
+    }
+}

--- a/app/src/main/java/com/arjunalabs/android/xkcdreader/ui/MainViewModel.kt
+++ b/app/src/main/java/com/arjunalabs/android/xkcdreader/ui/MainViewModel.kt
@@ -8,19 +8,18 @@ import com.arjunalabs.android.xkcdreader.usecase.GetLatestComic
 import com.arjunalabs.android.xkcdreader.usecase.GetLatestComicResult
 import io.reactivex.Observable
 import io.reactivex.Scheduler
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import javax.inject.Inject
+import javax.inject.Named
 
 class MainViewModel @Inject constructor(
         private val getComicByNumber: GetComicByNumber,
-        private val getLatestComic: GetLatestComic
+        private val getLatestComic: GetLatestComic,
+        @Named("schedulersIo") private val subscriberSchedulers: Scheduler,
+        @Named("schedulersMainThread")private val observerSchedulers: Scheduler
 ) : ViewModel(), StateObservable<MainActivityState> {
 
-    private val subscriberSchedulers: Scheduler = Schedulers.io()
-    private val observerSchedulers: Scheduler = AndroidSchedulers.mainThread()
     private val behaviorSubject = BehaviorSubject.create<MainActivityState>()
     private val compositeDisposable = CompositeDisposable()
     private var latestNum: Int = 0

--- a/app/src/test/java/com/arjunalabs/android/xkcdreader/ui/MainViewModelTest.kt
+++ b/app/src/test/java/com/arjunalabs/android/xkcdreader/ui/MainViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.arjunalabs.android.xkcdreader.ui
 
 import com.arjunalabs.android.xkcdreader.repository.XkcdData
-import com.arjunalabs.android.xkcdreader.ui.MainViewModel
 import com.arjunalabs.android.xkcdreader.ui.state.MainActivityState
 import com.arjunalabs.android.xkcdreader.usecase.GetComicByNumber
 import com.arjunalabs.android.xkcdreader.usecase.GetComicResult


### PR DESCRIPTION
### Inject the Scheduler on the MainViewModel

- Inject Schedulers.Io
- Inject AndroidSchedulers.mainThread()

Now the MainViewModel and the MainViewModelTest can run again.


### Inject the xkcdService on the MainViewModelModule

- Create RetrofitModule that provide the xkcdService
- Include the RetrofitModule on the MainViewModelModule

Now the xkcdService will automatically injected to MainViewModel.